### PR TITLE
SectorSeeder (dvg2311a_seeders)

### DIFF
--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+
+class Category extends Model
+{
+    protected $table= 'categories';
+    protected $rules= 
+    [
+        'name_category'
+    ];
+    
+    protected $fillable= 
+    [
+        'name_category', 'id_sector',
+    ];
+
+    public function sector()
+    {
+        return $this->hasMany('App\Models\Sector', 'id', 'id_sector');
+    }
+}

--- a/database/migrations/2023_10_04_192221_create_categories_table.php
+++ b/database/migrations/2023_10_04_192221_create_categories_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name_category');
+
+            $table->integer('id_sector')->unsigned();
+            $table->foreign('id_sector')->references('id')->
+            on('sectors')->onDelete('cascade')->onUpdate('cascade');
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class CategorySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+   
+    }
+}

--- a/database/seeders/SectorSeeder.php
+++ b/database/seeders/SectorSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Sector;
+
+class SectorSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+
+        $sectors = new Sector();
+        $sectors->name='INDUSTRIAL';
+        $sectors->description='ESTE ES UN SECTOR';
+        $sectors->save();
+
+        $sectors2= new Sector();
+        $sectors2->name='SERVICIO';
+        $sectors2->description='ESTE ES OTRO SECTOR';
+        $sectors2->save();
+
+        
+    }
+}


### PR DESCRIPTION
En esta rama se almacenarán los Seeders, todo con el fin de evitar un daño en la rama principal y mantener la integridad del proyecto. 

El primer seeder creado es 'SectorSeeder', tambén se incluye 'CategorySeeder', sin embargo, no realiza ninguna función en esta versión del proyecto. En el Seeder 'DatabaseSeeder' se manda a llamar a la clase 'SectorSeeder', para heredar todos sus datos:   $this->call(SectorSeeder::class);
----------------------------------------------------------------------------
Nota: Si dado un caso, no sale el comando antes colocado, no pasa nada en lo absoluto, es decir, el Seeder no funciona, pero tampoco afecta el funcionamiento del proyecto. Ahora bien, esto es algo por lo que no debemos preocuparnos, ya que si no sale, se reincorporará en la siguiente versión, qué, si hay un progreso significativo, se subirá el día 05/10/2023, si Dios lo permite. Cualquier duda, preguntarme.

Versión de Seeders: 1│Fecha: 05/10/2023.

Autor: dvg2311a